### PR TITLE
AllUsers Iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# users
+# redox_users
 
 Redox OS APIs for accessing users and groups information.
 
@@ -12,26 +12,27 @@ High level APIs for:
 - Getting the group information for a given group ID.
 - Getting the user information for a given username.
 - Getting a group information for a given group name.
+- Iterating over all the users on the system.
 
 We recommend to use these APIs instead of directly manipulating the
-`/etc/group` and `etc/passwd` as this is an implementation detail and
+`/etc/group` and `/etc/passwd` as this is an implementation detail and
 might change in the future.
 
-## Using users
+## Using redox_users
 
 Make sure you have Rust nightly.
 
-Add `rust_users` to `Cargo.toml`:
+Add `redox_users` to `Cargo.toml`:
 
 ```toml
-[dependencies.rust_users]
+[dependencies.redox_users]
 git = "https://github.com/redox-os/users.git"
 ```
 
 then import it in your main file:
 
 ```rust
-extern crate rust_users;
+extern crate redox_users;
 ```
 
-And `rust_users` is now ready to roll!
+And `redox_users` is now ready to roll!


### PR DESCRIPTION
Added iterator over all users of the system, refactoring and improved docs.

- Now the `parse_file` methods take a path to the file and not the string with the contents.
- `parse_file` methods now are only visible inside the crate.
- Derived `Debug` for structs.
- Improved docs by linking.
- Fixed the README.