### PR TITLE
Tests! Fix #15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,5 @@ keywords = ["redox", "auth"]
 [dependencies]
 argon2rs = { version = "0.2", default-features = false }
 rand = "0.4"
-extra = { git = "https://github.com/redox-os/libextra.git" }
 redox_syscall = "0.1"
 failure = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ description = "A Rust library to access Redox users and groups functionality"
 license = "MIT"
 repository = "https://github.com/redox-os/users"
 documentation = "https://docs.rs/redox_users"
+readme = "README.md"
+keywords = ["redox", "auth"]
 
 [dependencies]
 argon2rs = { version = "0.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ extern crate redox_users;
 ```
 
 And `redox_users` is now ready to roll!
+
+## Hashing
+redox_users uses the Argon2 hashing algorithm. The default hashing parameters are as follows:
+```Rust
+Argon2::new(10, 1, 4096, Variant::Argon2i)
+```

--- a/tests/group
+++ b/tests/group
@@ -1,0 +1,3 @@
+root;0;root
+user;1000;user
+wheel;1;user,root

--- a/tests/passwd
+++ b/tests/passwd
@@ -1,0 +1,2 @@
+root;$argon2i$m=4096,t=10,p=1$Tnc4UVV0N00$ML9LIOujd3nmAfkAwEcSTMPqakWUF0OUiLWrIy0nGLk;0;0;root;file:/root;file:/bin/ion
+user;;1000;1000;user;file:/home/user;file:/bin/ion


### PR DESCRIPTION
Fix #15, read and write aren't as dumb now. I removed locks for Linux read/write, because I'm not sure how to accomplish that locking on other platforms. Idk if std has a way to do it. Also, I should have used `#[cfg(not(redox))]`, so that's something to fix.

Tests are in! Doctests work, they all pass, as do the five that I wrote for that specific purpose. The doctests look good in the docs too.

I'm going to release this version of the crate on crates.io. I hope no one has any objections.